### PR TITLE
Replace non-existent GaugeIcon with RocketLaunchIcon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-react-typescript-starter",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-react-typescript-starter",
-      "version": "0.0.0",
+      "version": "1.2.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.1",

--- a/src/components/common/CarCard.tsx
+++ b/src/components/common/CarCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { HeartIcon, EyeIcon, CalendarIcon, GaugeIcon } from '@heroicons/react/24/outline';
+import { HeartIcon, EyeIcon, CalendarIcon, RocketLaunchIcon } from '@heroicons/react/24/outline';
 import { HeartIcon as HeartSolidIcon } from '@heroicons/react/24/solid';
 import { Car } from '../../types';
 import { useApp } from '../../context/AppContext';
@@ -81,7 +81,7 @@ const CarCard: React.FC<CarCardProps> = ({ car }) => {
             {car.year}
           </div>
           <div className="flex items-center">
-            <GaugeIcon className="h-4 w-4 mr-2 text-gray-400" />
+            <RocketLaunchIcon className="h-4 w-4 mr-2 text-gray-400" />
             {car.mileage.toLocaleString()} mi
           </div>
         </div>


### PR DESCRIPTION
The build was failing due to an import of `GaugeIcon` from `@heroicons/react/24/outline`, which does not exist.

This commit replaces `GaugeIcon` with `RocketLaunchIcon` to fix the build error. The `RocketLaunchIcon` is a suitable replacement as it conveys a sense of speed and performance, which is appropriate for displaying car mileage.